### PR TITLE
Add data-flip attributes to types

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
   "main": "src/flip.js",
   "module": "src/flip.js",
   "exports": "./src/flip.js",
-  "types": "dist/flip.d.ts",
+  "types": "types/index.d.ts",
   "files": [
     "src",
-    "dist",
+    "types",
     "README.md"
   ],
   "sideEffects": false,

--- a/tsconfig.types.json
+++ b/tsconfig.types.json
@@ -4,7 +4,7 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "noEmit": false,
-    "outDir": "dist",
+    "outDir": "types",
     "allowJs": true,
     "checkJs": true,
     "skipLibCheck": true

--- a/types/flip.d.ts
+++ b/types/flip.d.ts
@@ -1,0 +1,88 @@
+/**
+ * Easing values accepted by the Web Animations API's `easing` option.
+ * Matches the CSS `animation-timing-function` and `transition-timing-function` syntax.
+ * @typedef {("linear"|"ease"|"ease-in"|"ease-out"|"ease-in-out"|"step-start"|"step-end"|`cubic-bezier(${string})`|`steps(${number})`|`steps(${number},start)`|`steps(${number}, end)`|`linear(${string})`)} EasingFunctions
+ */
+/**
+ * Minimal FLIP utility with translation and optional scale, Promise-based play,
+ * reduced-motion support, and basic controls.
+ *
+ * Usage pattern:
+ *   const ctrl = flip(elements);
+ *   // ...mutate DOM (reorder/insert/remove)
+ *   await ctrl.play({ duration: 300 }).finished;
+ *
+ * @template {HTMLElement[]  | NodeListOf<HTMLElement> | HTMLCollectionOf<HTMLElement> } T
+ * @param {T} elements
+ */
+export default function flip<T extends HTMLElement[] | NodeListOf<HTMLElement> | HTMLCollectionOf<HTMLElement>>(elements: T): {
+    play: (options?: {
+        duration?: number;
+        easing?: EasingFunctions;
+        delay?: number;
+        stagger?: number | ((index: number, count: number, element: HTMLElement) => number);
+        fill?: FillMode;
+        direction?: PlaybackDirection;
+        composite?: CompositeOperation;
+        shouldScale?: boolean;
+        respectReducedMotion?: boolean;
+        transformOrigin?: string;
+        epsilon?: number;
+        interrupt?: "cancel" | "ignore" | "queue";
+        onStart?: (ctx: {
+            options: /*elided*/ any;
+            count: number;
+            animations: Animation[];
+        }) => void;
+        onEachStart?: (entry: {
+            element: HTMLElement;
+            index: number;
+            prevBox: DOMRectReadOnly;
+            nowBox: DOMRectReadOnly;
+            delta: {
+                dx: number;
+                dy: number;
+                scaleX: number;
+                scaleY: number;
+            };
+        }, ctx: {
+            options: /*elided*/ any;
+            count: number;
+            animations: Animation[];
+        }) => void;
+        onEachFinish?: (entry: {
+            element: HTMLElement;
+            index: number;
+            prevBox: DOMRectReadOnly;
+            nowBox: DOMRectReadOnly;
+            delta: {
+                dx: number;
+                dy: number;
+                scaleX: number;
+                scaleY: number;
+            };
+        }, ctx: {
+            options: /*elided*/ any;
+            count: number;
+            animations: Animation[];
+        }) => void;
+        onFinish?: (ctx: {
+            options: /*elided*/ any;
+            count: number;
+            animations: Animation[];
+        }) => void;
+    }) => {
+        animations: Animation[];
+        finished: Promise<void>;
+        cancel: () => void;
+    };
+    measure: () => DOMRect[];
+    update: <U extends HTMLElement[] | NodeListOf<HTMLElement> | HTMLCollectionOf<HTMLElement>>(newElements?: U) => void;
+    cancel: () => void;
+    disconnect: () => void;
+};
+/**
+ * Easing values accepted by the Web Animations API's `easing` option.
+ * Matches the CSS `animation-timing-function` and `transition-timing-function` syntax.
+ */
+export type EasingFunctions = ("linear" | "ease" | "ease-in" | "ease-out" | "ease-in-out" | "step-start" | "step-end" | `cubic-bezier(${string})` | `steps(${number})` | `steps(${number},start)` | `steps(${number}, end)` | `linear(${string})`);

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,20 @@
+export { default } from './flip';
+export * from './flip';
+
+declare global {
+  namespace JSX {
+    interface HTMLAttributes<T> {
+      'data-flip-duration'?: number | string;
+      'data-flip-duration-offset'?: number | string;
+      'data-flip-delay'?: number | string;
+    }
+  }
+}
+
+declare module 'react' {
+  interface HTMLAttributes<T> {
+    'data-flip-duration'?: number | string;
+    'data-flip-duration-offset'?: number | string;
+    'data-flip-delay'?: number | string;
+  }
+}


### PR DESCRIPTION
Adds `data-flip-*` attributes to `HTMLAttributes` and moves generated type declarations to the `/types/` directory to provide correct typings and improve type output organization.

---
<a href="https://cursor.com/background-agent?bcId=bc-7120b1de-d04e-4be3-9fa6-b9e1a5a45be0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7120b1de-d04e-4be3-9fa6-b9e1a5a45be0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

