### PR TITLE
Update readme with easing and duration info

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,16 +36,37 @@ await ctrl.play({ duration: 300, easing: 'ease' }).finished;
 ### Options
 
 - `duration` (ms, default 100)
-- `easing` (default `ease`)
+- `easing` (default `ease`). Accepts any CSS timing function string supported by WAAPI: `linear`, `ease`, `ease-in`, `ease-out`, `ease-in-out`, `step-start`, `step-end`, `cubic-bezier(...)`, `steps(n[, start|end])`, `linear(...)`.
 - `delay` (default 0)
 - `stagger` (ms per index, default 0)
-- `fill` (default `auto`)
+- `fill` (default `both`)
 - `direction` (default `normal`)
 - `composite` (default `add`)
 - `shouldScale` (default `true`)
 - `respectReducedMotion` (default `true`)
 - `transformOrigin` (default `"0 0"`)
 - `epsilon` (px threshold to skip, default `0.5`)
+
+### Per-element overrides (data attributes)
+
+- `data-flip-duration`: absolute duration in ms for that element (overrides `options.duration`)
+- `data-flip-duration-offset`: value added to `options.duration` for that element (ignored if `data-flip-duration` is present)
+- `data-flip-delay`: absolute delay in ms for that element (overrides base `delay` + `stagger`)
+
+Example:
+
+```html
+<li data-flip-duration="200"></li>
+<li data-flip-duration-offset="50" data-flip-delay="100"></li>
+```
+
+Or via JS:
+
+```js
+el.dataset.flipDuration = '200';
+el.dataset.flipDurationOffset = '50';
+el.dataset.flipDelay = '100';
+```
 
 ## Development
 


### PR DESCRIPTION
Update README to document available easing functions, per-element duration/delay control via data attributes, and correct the default `fill` option.

---
<a href="https://cursor.com/background-agent?bcId=bc-41ea905b-a6bc-445a-b6f7-37fdec197835">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-41ea905b-a6bc-445a-b6f7-37fdec197835">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

