### PR TITLE
Update flip.js to recalculate stagger indices dynamically

### DIFF
--- a/src/flip.js
+++ b/src/flip.js
@@ -89,10 +89,6 @@ export default function flip(elements) {
       const firstWithParent = els.find((el) => !!el && !!el.parentElement) || null;
       const parent = firstWithParent ? firstWithParent.parentElement : null;
       if (!parent) return new Map();
-      // Ensure common parent
-      for (let i = 0; i < els.length; i += 1) {
-        if (els[i].parentElement !== parent) return new Map();
-      }
       const map = new Map();
       const children = parent.children;
       for (let i = 0; i < children.length; i += 1) {

--- a/src/flip.js
+++ b/src/flip.js
@@ -17,20 +17,26 @@
  * @param {T} elements
  */
 export default function flip(elements) {
-  const indexMap = buildDomIndexMap(Array.from(elements));
-  const elementBoxes = Array.from(elements).map((element, i) => ({
-    element,
-    box: element.getBoundingClientRect(),
-    /** DOM index relative to siblings at time of flip() call (fallback to provided order) */
-    index: indexMap.get(element) ?? i,
-  }));
+  const initialElements = Array.from(elements);
+  const indexMapByParent = buildDomIndexMap(initialElements);
+  const elementBoxes = initialElements.map((element, i) => {
+    const parent = element.parentElement || null;
+    const fromIndex = parent ? (indexMapByParent.get(parent)?.get(element) ?? i) : i;
+    return {
+      element,
+      box: element.getBoundingClientRect(),
+      /** DOM parent and index relative to siblings at time of flip() (fallbacks to provided order) */
+      parent,
+      index: fromIndex,
+    };
+  });
 
   /**
    * @typedef {Object} FlipOptions
    * @property {number} [duration=100]
    * @property {EasingFunctions} [easing='ease']
    * @property {number} [delay=0]
-   * @property {number | ((index: number, count: number, element: HTMLElement) => number)} [stagger=0]
+   * @property {number | ((index: number, count: number, element: HTMLElement) => number) | ((ctx: { element: HTMLElement; from: { parent: HTMLElement | null; index: number; rect: DOMRectReadOnly }; to: { parent: HTMLElement | null; index: number; rect: DOMRectReadOnly } }) => number)} [stagger=0]
    * @property {FillMode} [fill='both']
    * @property {PlaybackDirection} [direction='normal']
    * @property {CompositeOperation} [composite='add']
@@ -79,25 +85,32 @@ export default function flip(elements) {
   }
 
   /**
-   * Build a map of DOM indices for elements that share a common parentElement.
-   * If no common parent exists, returns an empty map.
+   * Build maps of DOM indices per parent for provided elements.
    * @param {HTMLElement[]} els
-   * @returns {Map<Element, number>}
+   * @returns {Map<HTMLElement, Map<Element, number>>}
    */
   function buildDomIndexMap(els) {
+    /** @type {Map<HTMLElement, Map<Element, number>>} */
+    const parentToIndex = new Map();
     try {
-      const firstWithParent = els.find((el) => !!el && !!el.parentElement) || null;
-      const parent = firstWithParent ? firstWithParent.parentElement : null;
-      if (!parent) return new Map();
-      const map = new Map();
-      const children = parent.children;
-      for (let i = 0; i < children.length; i += 1) {
-        map.set(children[i], i);
+      /** @type {Map<HTMLElement, true>} */
+      const parents = new Map();
+      for (let i = 0; i < els.length; i += 1) {
+        const p = els[i]?.parentElement || null;
+        if (p) parents.set(p, true);
       }
-      return map;
+      parents.forEach((_, parent) => {
+        const map = new Map();
+        const children = parent.children;
+        for (let i = 0; i < children.length; i += 1) {
+          map.set(children[i], i);
+        }
+        parentToIndex.set(parent, map);
+      });
     } catch {
-      return new Map();
+      // ignore; return what we have (possibly empty)
     }
+    return parentToIndex;
   }
 
   function measure() {
@@ -114,10 +127,12 @@ export default function flip(elements) {
   function update(newElements) {
     if (newElements) {
       const next = Array.from(newElements);
-      const idxMap = buildDomIndexMap(next);
+      const idxMapByParent = buildDomIndexMap(next);
       elementBoxes.length = 0;
       next.forEach((element, i) => {
-        elementBoxes.push({ element, box: element.getBoundingClientRect(), index: idxMap.get(element) ?? i });
+        const parent = element.parentElement || null;
+        const idx = parent ? (idxMapByParent.get(parent)?.get(element) ?? i) : i;
+        elementBoxes.push({ element, box: element.getBoundingClientRect(), parent, index: idx });
       });
     } else {
       measure();
@@ -206,9 +221,13 @@ export default function flip(elements) {
       const entries = elementBoxes.map((record) => ({
         element: record.element,
         index: record.index,
+        parent: record.parent,
         prevBox: record.box,
         nowBox: record.element.getBoundingClientRect(),
       }));
+
+      // Precompute current indices per parent for "to" state
+      const toIdxMapByParent = buildDomIndexMap(elementBoxes.map((r) => r.element));
 
       // Phase 2: compute
       const computed = entries.map((entry) => {
@@ -244,11 +263,38 @@ export default function flip(elements) {
       // Phase 3: writes and start animations
       const count = computed.length;
       const baseDelay = opts.delay || 0;
-      /** @type {(i: number, c: number, el: HTMLElement) => number} */
-      const staggerResolver =
-        typeof opts.stagger === 'function'
-          ? (i, c, el) => baseDelay + /** @type {Exclude<FlipOptions['stagger'], number>} */ (opts.stagger)(i, c, el)
-          : (i) => baseDelay + i * ((/** @type {number} */ (opts.stagger)) || 0);
+
+      /** Resolve per-element delay */
+      function resolveDelayFor(c) {
+        const el = c.entry.element;
+        const fromParent = c.entry.parent || el.parentElement || null;
+        const fromIndex = c.entry.index;
+        const toParent = el.parentElement || null;
+        const toIndex = toParent ? (toIdxMapByParent.get(toParent)?.get(el) ?? fromIndex) : fromIndex;
+
+        /** @type {number} */
+        let resolved = 0;
+        if (typeof opts.stagger === 'number') {
+          resolved = (/** @type {number} */ (opts.stagger) || 0) * fromIndex;
+        } else if (typeof opts.stagger === 'function') {
+          const fn = /** @type {Function} */ (opts.stagger);
+          if (fn.length <= 1) {
+            // New API: single context argument
+            const ctx = {
+              element: el,
+              from: { parent: fromParent, index: fromIndex, rect: c.entry.prevBox },
+              to: { parent: toParent, index: toIndex, rect: c.entry.nowBox },
+            };
+            const v = Number(fn(ctx));
+            resolved = Number.isFinite(v) ? v : 0;
+          } else {
+            // Legacy API: (index, count, element)
+            const v = Number(fn(fromIndex, count, el));
+            resolved = Number.isFinite(v) ? v : 0;
+          }
+        }
+        return baseDelay + resolved;
+      }
 
       computed.forEach((c) => {
         if (c.isNegligible) return;
@@ -267,7 +313,7 @@ export default function flip(elements) {
 
         try {
           c.entry.element.style.willChange = 'transform';
-          const delay = staggerResolver(c.entry.index, count, c.entry.element);
+          const delay = resolveDelayFor(c);
           // Per-element overrides via data attributes
           // data-flip-duration: absolute duration in ms for this element
           // data-flip-duration-offset: added to options.duration; ignored if data-flip-duration is present
@@ -312,15 +358,15 @@ export default function flip(elements) {
         } catch { /* ignore */ }
       });
 
-      // After starting animations, optionally recalculate and store new DOM indices using a single-pass map
+      // After starting animations, optionally recalculate and store new DOM indices using the multi-parent map
       if (opts.recalculateIndices) {
-        const idxMap = buildDomIndexMap(elementBoxes.map((r) => r.element));
-        if (idxMap.size > 0) {
-          elementBoxes.forEach((record) => {
-            const nextIndex = idxMap.get(record.element);
-            if (typeof nextIndex === 'number') record.index = nextIndex;
-          });
-        }
+        const idxMap = toIdxMapByParent;
+        elementBoxes.forEach((record) => {
+          const p = record.element.parentElement || null;
+          record.parent = p;
+          const nextIndex = p ? idxMap.get(p)?.get(record.element) : undefined;
+          if (typeof nextIndex === 'number') record.index = nextIndex;
+        });
       }
 
       currentAnimations = animations;

--- a/types/flip.d.ts
+++ b/types/flip.d.ts
@@ -20,7 +20,19 @@ export default function flip<T extends HTMLElement[] | NodeListOf<HTMLElement> |
         duration?: number;
         easing?: EasingFunctions;
         delay?: number;
-        stagger?: number | ((index: number, count: number, element: HTMLElement) => number);
+        stagger?: number | ((index: number, count: number, element: HTMLElement) => number) | ((ctx: {
+            element: HTMLElement;
+            from: {
+                parent: HTMLElement | null;
+                index: number;
+                rect: DOMRectReadOnly;
+            };
+            to: {
+                parent: HTMLElement | null;
+                index: number;
+                rect: DOMRectReadOnly;
+            };
+        }) => number);
         fill?: FillMode;
         direction?: PlaybackDirection;
         composite?: CompositeOperation;

--- a/types/flip.d.ts
+++ b/types/flip.d.ts
@@ -29,6 +29,7 @@ export default function flip<T extends HTMLElement[] | NodeListOf<HTMLElement> |
         transformOrigin?: string;
         epsilon?: number;
         interrupt?: "cancel" | "ignore" | "queue";
+        recalculateIndices?: boolean;
         onStart?: (ctx: {
             options: /*elided*/ any;
             count: number;


### PR DESCRIPTION
Add `recalculateIndices` option to `play()` to enable dynamic stagger index updates based on current DOM position.

---
<a href="https://cursor.com/background-agent?bcId=bc-23e31991-a412-440b-87e1-b217c2d1f790">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-23e31991-a412-440b-87e1-b217c2d1f790">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

